### PR TITLE
Address PR #15 review: complete applySiblingSchemaFields, fix 3.0 regression, gate 3.1 fields

### DIFF
--- a/openapi3/issue495_test.go
+++ b/openapi3/issue495_test.go
@@ -121,7 +121,10 @@ paths:
 	doc, err := sl.LoadFromData(spec)
 	require.NoError(t, err)
 
-	err = doc.Validate(sl.Context)
+	// draft-04 meta-schema contains $id and $schema; in OAS 3.0 these require
+	// opt-in via AllowExtraSiblingFields so the test can assert its real target
+	// (the unresolved inner "#" ref).
+	err = doc.Validate(sl.Context, AllowExtraSiblingFields("$id", "$schema"))
 	require.ErrorContains(t, err, `found unresolved ref: "#"`)
 }
 
@@ -157,6 +160,9 @@ paths:
 	doc, err := sl.LoadFromData(spec)
 	require.NoError(t, err)
 
-	err = doc.Validate(sl.Context)
+	// draft-04 meta-schema contains $id and $schema; in OAS 3.0 these require
+	// opt-in via AllowExtraSiblingFields so the test can assert its real target
+	// (the unresolved inner "#" ref).
+	err = doc.Validate(sl.Context, AllowExtraSiblingFields("$id", "$schema"))
 	require.ErrorContains(t, err, `found unresolved ref: "#"`)
 }

--- a/openapi3/issue601_test.go
+++ b/openapi3/issue601_test.go
@@ -17,11 +17,13 @@ func TestIssue601(t *testing.T) {
 	doc, err := sl.LoadFromFile("testdata/lxkns.yaml")
 	require.NoError(t, err)
 
-	err = doc.Validate(sl.Context)
+	// lxkns.yaml has `description` siblings alongside $ref (invalid in OAS 3.0).
+	// Allow them so we can exercise the example-type validation this test actually targets.
+	err = doc.Validate(sl.Context, AllowExtraSiblingFields("description"))
 	require.ErrorContains(t, err, `invalid components: schema "DiscoveryResult": invalid example: Error at "/type": property "type" is missing`)
 	require.ErrorContains(t, err, `| Error at "/nsid": property "nsid" is missing`)
 
-	err = doc.Validate(sl.Context, DisableExamplesValidation())
+	err = doc.Validate(sl.Context, AllowExtraSiblingFields("description"), DisableExamplesValidation())
 	require.NoError(t, err)
 
 	// Now let's remove all the invalid parts
@@ -29,6 +31,6 @@ func TestIssue601(t *testing.T) {
 		schema.Value.Example = nil
 	}
 
-	err = doc.Validate(sl.Context)
+	err = doc.Validate(sl.Context, AllowExtraSiblingFields("description"))
 	require.NoError(t, err)
 }

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -1354,25 +1354,130 @@ func unescapeRefString(ref string) string {
 // Only fields that were explicitly present in the original YAML/JSON are applied; the presentFields
 // slice (derived from SchemaRef.extra) carries this information.
 func applySiblingSchemaFields(dst, sibling *Schema, presentFields []string) {
-	// FIXME(reuvenharrison): complete with missing Schema fields + Origin?
 	for _, field := range presentFields {
 		switch field {
-		case "deprecated":
-			dst.Deprecated = sibling.Deprecated
-		case "description":
-			dst.Description = sibling.Description
+		case "oneOf":
+			dst.OneOf = sibling.OneOf
+		case "anyOf":
+			dst.AnyOf = sibling.AnyOf
+		case "allOf":
+			dst.AllOf = sibling.AllOf
+		case "not":
+			dst.Not = sibling.Not
+		case "type":
+			dst.Type = sibling.Type
 		case "title":
 			dst.Title = sibling.Title
-		case "readOnly":
-			dst.ReadOnly = sibling.ReadOnly
-		case "writeOnly":
-			dst.WriteOnly = sibling.WriteOnly
+		case "format":
+			dst.Format = sibling.Format
+		case "description":
+			dst.Description = sibling.Description
+		case "enum":
+			dst.Enum = sibling.Enum
+		case "default":
+			dst.Default = sibling.Default
 		case "example":
 			dst.Example = sibling.Example
 		case "externalDocs":
 			dst.ExternalDocs = sibling.ExternalDocs
-		case "default":
-			dst.Default = sibling.Default
+		case "uniqueItems":
+			dst.UniqueItems = sibling.UniqueItems
+		case "exclusiveMinimum":
+			dst.ExclusiveMin = sibling.ExclusiveMin
+		case "exclusiveMaximum":
+			dst.ExclusiveMax = sibling.ExclusiveMax
+		case "nullable":
+			dst.Nullable = sibling.Nullable
+		case "readOnly":
+			dst.ReadOnly = sibling.ReadOnly
+		case "writeOnly":
+			dst.WriteOnly = sibling.WriteOnly
+		case "allowEmptyValue":
+			dst.AllowEmptyValue = sibling.AllowEmptyValue
+		case "deprecated":
+			dst.Deprecated = sibling.Deprecated
+		case "xml":
+			dst.XML = sibling.XML
+		case "minimum":
+			dst.Min = sibling.Min
+		case "maximum":
+			dst.Max = sibling.Max
+		case "multipleOf":
+			dst.MultipleOf = sibling.MultipleOf
+		case "minLength":
+			dst.MinLength = sibling.MinLength
+		case "maxLength":
+			dst.MaxLength = sibling.MaxLength
+		case "pattern":
+			dst.Pattern = sibling.Pattern
+		case "minItems":
+			dst.MinItems = sibling.MinItems
+		case "maxItems":
+			dst.MaxItems = sibling.MaxItems
+		case "items":
+			dst.Items = sibling.Items
+		case "required":
+			dst.Required = sibling.Required
+		case "properties":
+			dst.Properties = sibling.Properties
+		case "minProperties":
+			dst.MinProps = sibling.MinProps
+		case "maxProperties":
+			dst.MaxProps = sibling.MaxProps
+		case "additionalProperties":
+			dst.AdditionalProperties = sibling.AdditionalProperties
+		case "discriminator":
+			dst.Discriminator = sibling.Discriminator
+		case "const":
+			dst.Const = sibling.Const
+		case "examples":
+			dst.Examples = sibling.Examples
+		case "prefixItems":
+			dst.PrefixItems = sibling.PrefixItems
+		case "contains":
+			dst.Contains = sibling.Contains
+		case "minContains":
+			dst.MinContains = sibling.MinContains
+		case "maxContains":
+			dst.MaxContains = sibling.MaxContains
+		case "patternProperties":
+			dst.PatternProperties = sibling.PatternProperties
+		case "dependentSchemas":
+			dst.DependentSchemas = sibling.DependentSchemas
+		case "propertyNames":
+			dst.PropertyNames = sibling.PropertyNames
+		case "unevaluatedItems":
+			dst.UnevaluatedItems = sibling.UnevaluatedItems
+		case "unevaluatedProperties":
+			dst.UnevaluatedProperties = sibling.UnevaluatedProperties
+		case "if":
+			dst.If = sibling.If
+		case "then":
+			dst.Then = sibling.Then
+		case "else":
+			dst.Else = sibling.Else
+		case "dependentRequired":
+			dst.DependentRequired = sibling.DependentRequired
+		case "$defs":
+			dst.Defs = sibling.Defs
+		case "$schema":
+			dst.SchemaDialect = sibling.SchemaDialect
+		case "$comment":
+			dst.Comment = sibling.Comment
+		case "$id":
+			dst.SchemaID = sibling.SchemaID
+		case "$anchor":
+			dst.Anchor = sibling.Anchor
+		case "$dynamicRef":
+			dst.DynamicRef = sibling.DynamicRef
+		case "$dynamicAnchor":
+			dst.DynamicAnchor = sibling.DynamicAnchor
+		case "contentMediaType":
+			dst.ContentMediaType = sibling.ContentMediaType
+		case "contentEncoding":
+			dst.ContentEncoding = sibling.ContentEncoding
+		case "contentSchema":
+			dst.ContentSchema = sibling.ContentSchema
 		}
 	}
 }

--- a/openapi3/loader_31_schema_refs_test.go
+++ b/openapi3/loader_31_schema_refs_test.go
@@ -80,11 +80,6 @@ components:
 
 			require.Equal(t, tc.siblings, statusRef.Value.Deprecated, "deprecated:true sibling to $ref must be honoured in OAS 3.1")
 
-			x := testcase{oas: "3.0"}
-			if tc == x {
-				t.Skip("FIXME(reuvenharrison): make the skipped test pass")
-			}
-
 			var valopts []openapi3.ValidationOption
 			if tc.valid && !tc.siblings { // For this test case let's try the option that allows siblings for 3.0
 				valopts = append(valopts, openapi3.AllowExtraSiblingFields("deprecated"))

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -94,9 +94,9 @@ func (x *CallbackRef) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if CallbackRef does not comply with the OpenAPI spec.
-func (x *CallbackRef) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if CallbackRef has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *CallbackRef) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -123,6 +123,15 @@ func (x *CallbackRef) Validate(ctx context.Context, opts ...ValidationOption) er
 
 	if len(extras) != 0 {
 		return fmt.Errorf("extra sibling fields: %+v", extras)
+	}
+	return nil
+}
+
+// Validate returns an error if CallbackRef does not comply with the OpenAPI spec.
+func (x *CallbackRef) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {
@@ -227,9 +236,9 @@ func (x *ExampleRef) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if ExampleRef does not comply with the OpenAPI spec.
-func (x *ExampleRef) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if ExampleRef has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *ExampleRef) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -256,6 +265,15 @@ func (x *ExampleRef) Validate(ctx context.Context, opts ...ValidationOption) err
 
 	if len(extras) != 0 {
 		return fmt.Errorf("extra sibling fields: %+v", extras)
+	}
+	return nil
+}
+
+// Validate returns an error if ExampleRef does not comply with the OpenAPI spec.
+func (x *ExampleRef) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {
@@ -360,9 +378,9 @@ func (x *HeaderRef) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if HeaderRef does not comply with the OpenAPI spec.
-func (x *HeaderRef) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if HeaderRef has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *HeaderRef) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -389,6 +407,15 @@ func (x *HeaderRef) Validate(ctx context.Context, opts ...ValidationOption) erro
 
 	if len(extras) != 0 {
 		return fmt.Errorf("extra sibling fields: %+v", extras)
+	}
+	return nil
+}
+
+// Validate returns an error if HeaderRef does not comply with the OpenAPI spec.
+func (x *HeaderRef) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {
@@ -493,9 +520,9 @@ func (x *LinkRef) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if LinkRef does not comply with the OpenAPI spec.
-func (x *LinkRef) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if LinkRef has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *LinkRef) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -522,6 +549,15 @@ func (x *LinkRef) Validate(ctx context.Context, opts ...ValidationOption) error 
 
 	if len(extras) != 0 {
 		return fmt.Errorf("extra sibling fields: %+v", extras)
+	}
+	return nil
+}
+
+// Validate returns an error if LinkRef does not comply with the OpenAPI spec.
+func (x *LinkRef) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {
@@ -626,9 +662,9 @@ func (x *ParameterRef) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if ParameterRef does not comply with the OpenAPI spec.
-func (x *ParameterRef) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if ParameterRef has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *ParameterRef) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -655,6 +691,15 @@ func (x *ParameterRef) Validate(ctx context.Context, opts ...ValidationOption) e
 
 	if len(extras) != 0 {
 		return fmt.Errorf("extra sibling fields: %+v", extras)
+	}
+	return nil
+}
+
+// Validate returns an error if ParameterRef does not comply with the OpenAPI spec.
+func (x *ParameterRef) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {
@@ -759,9 +804,9 @@ func (x *RequestBodyRef) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if RequestBodyRef does not comply with the OpenAPI spec.
-func (x *RequestBodyRef) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if RequestBodyRef has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *RequestBodyRef) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -788,6 +833,15 @@ func (x *RequestBodyRef) Validate(ctx context.Context, opts ...ValidationOption)
 
 	if len(extras) != 0 {
 		return fmt.Errorf("extra sibling fields: %+v", extras)
+	}
+	return nil
+}
+
+// Validate returns an error if RequestBodyRef does not comply with the OpenAPI spec.
+func (x *RequestBodyRef) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {
@@ -892,9 +946,9 @@ func (x *ResponseRef) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if ResponseRef does not comply with the OpenAPI spec.
-func (x *ResponseRef) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if ResponseRef has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *ResponseRef) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -921,6 +975,15 @@ func (x *ResponseRef) Validate(ctx context.Context, opts ...ValidationOption) er
 
 	if len(extras) != 0 {
 		return fmt.Errorf("extra sibling fields: %+v", extras)
+	}
+	return nil
+}
+
+// Validate returns an error if ResponseRef does not comply with the OpenAPI spec.
+func (x *ResponseRef) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {
@@ -1044,9 +1107,9 @@ func (x *SchemaRef) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if SchemaRef does not comply with the OpenAPI spec.
-func (x *SchemaRef) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if SchemaRef has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *SchemaRef) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -1075,6 +1138,15 @@ func (x *SchemaRef) Validate(ctx context.Context, opts ...ValidationOption) erro
 		if !validationOpts.isOpenAPI31OrLater {
 			return fmt.Errorf("extra sibling fields: %+v", extras)
 		}
+	}
+	return nil
+}
+
+// Validate returns an error if SchemaRef does not comply with the OpenAPI spec.
+func (x *SchemaRef) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {
@@ -1179,9 +1251,9 @@ func (x *SecuritySchemeRef) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if SecuritySchemeRef does not comply with the OpenAPI spec.
-func (x *SecuritySchemeRef) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if SecuritySchemeRef has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *SecuritySchemeRef) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -1208,6 +1280,15 @@ func (x *SecuritySchemeRef) Validate(ctx context.Context, opts ...ValidationOpti
 
 	if len(extras) != 0 {
 		return fmt.Errorf("extra sibling fields: %+v", extras)
+	}
+	return nil
+}
+
+// Validate returns an error if SecuritySchemeRef does not comply with the OpenAPI spec.
+func (x *SecuritySchemeRef) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {

--- a/openapi3/refs.tmpl
+++ b/openapi3/refs.tmpl
@@ -117,9 +117,9 @@ func (x *{{ $type.Name }}Ref) UnmarshalJSON(data []byte) error {
 	return json.Unmarshal(data, &x.Value)
 }
 
-// Validate returns an error if {{ $type.Name }}Ref does not comply with the OpenAPI spec.
-func (x *{{ $type.Name }}Ref) Validate(ctx context.Context, opts ...ValidationOption) error {
-	ctx = WithValidationOptions(ctx, opts...)
+// validateExtras returns an error if {{ $type.Name }}Ref has sibling fields
+// alongside $ref that are not allowed by the validation options.
+func (x *{{ $type.Name }}Ref) validateExtras(ctx context.Context) error {
 	validationOpts := getValidationOptions(ctx)
 	var extras []string
 
@@ -152,6 +152,15 @@ func (x *{{ $type.Name }}Ref) Validate(ctx context.Context, opts ...ValidationOp
 {{- else }}
 		return fmt.Errorf("extra sibling fields: %+v", extras)
 {{- end }}
+	}
+	return nil
+}
+
+// Validate returns an error if {{ $type.Name }}Ref does not comply with the OpenAPI spec.
+func (x *{{ $type.Name }}Ref) Validate(ctx context.Context, opts ...ValidationOption) error {
+	ctx = WithValidationOptions(ctx, opts...)
+	if err := x.validateExtras(ctx); err != nil {
+		return err
 	}
 
 	if v := x.Value; v != nil {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1425,6 +1425,146 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		return stack, errors.New("a property MUST NOT be marked as both readOnly and writeOnly being true")
 	}
 
+	// Reject fields that only exist in OAS 3.1 / JSON Schema 2020-12 when the
+	// document is OAS 3.0. Fields explicitly allowed via AllowExtraSiblingFields
+	// are skipped (opt-in escape hatch for 3.0 docs that reference external
+	// JSON Schema documents). Once 3.0 moves to its own schema validator this
+	// block becomes a no-op.
+	if !validationOpts.isOpenAPI31OrLater {
+		allowed := validationOpts.extraSiblingFieldsAllowed
+		reject := func(field string) error {
+			if _, ok := allowed[field]; ok {
+				return nil
+			}
+			return errFieldFor31Plus(field)
+		}
+		if schema.Const != nil {
+			if err := reject("const"); err != nil {
+				return stack, err
+			}
+		}
+		if len(schema.Examples) != 0 {
+			if err := reject("examples"); err != nil {
+				return stack, err
+			}
+		}
+		if len(schema.PrefixItems) != 0 {
+			if err := reject("prefixItems"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.Contains != nil {
+			if err := reject("contains"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.MinContains != nil {
+			if err := reject("minContains"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.MaxContains != nil {
+			if err := reject("maxContains"); err != nil {
+				return stack, err
+			}
+		}
+		if len(schema.PatternProperties) != 0 {
+			if err := reject("patternProperties"); err != nil {
+				return stack, err
+			}
+		}
+		if len(schema.DependentSchemas) != 0 {
+			if err := reject("dependentSchemas"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.PropertyNames != nil {
+			if err := reject("propertyNames"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.UnevaluatedItems.Has != nil || schema.UnevaluatedItems.Schema != nil {
+			if err := reject("unevaluatedItems"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.UnevaluatedProperties.Has != nil || schema.UnevaluatedProperties.Schema != nil {
+			if err := reject("unevaluatedProperties"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.If != nil {
+			if err := reject("if"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.Then != nil {
+			if err := reject("then"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.Else != nil {
+			if err := reject("else"); err != nil {
+				return stack, err
+			}
+		}
+		if len(schema.DependentRequired) != 0 {
+			if err := reject("dependentRequired"); err != nil {
+				return stack, err
+			}
+		}
+		if len(schema.Defs) != 0 {
+			if err := reject("$defs"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.SchemaDialect != "" {
+			if err := reject("$schema"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.Comment != "" {
+			if err := reject("$comment"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.SchemaID != "" {
+			if err := reject("$id"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.Anchor != "" {
+			if err := reject("$anchor"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.DynamicRef != "" {
+			if err := reject("$dynamicRef"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.DynamicAnchor != "" {
+			if err := reject("$dynamicAnchor"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.ContentMediaType != "" {
+			if err := reject("contentMediaType"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.ContentEncoding != "" {
+			if err := reject("contentEncoding"); err != nil {
+				return stack, err
+			}
+		}
+		if schema.ContentSchema != nil {
+			if err := reject("contentSchema"); err != nil {
+				return stack, err
+			}
+		}
+	}
+
 	for _, item := range schema.OneOf {
 		v := item.Value
 		if v == nil {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1568,6 +1568,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	}
 
 	if ref := schema.Items; ref != nil {
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1586,6 +1589,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	slices.Sort(properties)
 	for _, name := range properties {
 		ref := schema.Properties[name]
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1601,6 +1607,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		return stack, errors.New("additionalProperties are set to both boolean and schema")
 	}
 	if ref := schema.AdditionalProperties.Schema; ref != nil {
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1614,6 +1623,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 
 	// OpenAPI 3.1 / JSON Schema 2020-12 sub-schemas
 	for _, ref := range schema.PrefixItems {
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1625,6 +1637,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		}
 	}
 	if ref := schema.Contains; ref != nil {
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1637,6 +1652,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	}
 	for _, name := range componentNames(schema.PatternProperties) {
 		ref := schema.PatternProperties[name]
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1649,6 +1667,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	}
 	for _, name := range componentNames(schema.DependentSchemas) {
 		ref := schema.DependentSchemas[name]
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1661,6 +1682,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	}
 	for _, name := range componentNames(schema.Defs) {
 		ref := schema.Defs[name]
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1672,6 +1696,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		}
 	}
 	if ref := schema.PropertyNames; ref != nil {
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1686,6 +1713,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		return stack, errors.New("unevaluatedItems is set to both boolean and schema")
 	}
 	if ref := schema.UnevaluatedItems.Schema; ref != nil {
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1700,6 +1730,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		return stack, errors.New("unevaluatedProperties is set to both boolean and schema")
 	}
 	if ref := schema.UnevaluatedProperties.Schema; ref != nil {
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)
@@ -1711,6 +1744,9 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		}
 	}
 	if ref := schema.ContentSchema; ref != nil {
+		if err := ref.validateExtras(ctx); err != nil {
+			return stack, err
+		}
 		v := ref.Value
 		if v == nil {
 			return stack, foundUnresolvedRef(ref.Ref)

--- a/openapi3/schema_if_then_else_test.go
+++ b/openapi3/schema_if_then_else_test.go
@@ -176,7 +176,7 @@ func TestSchemaIfThenElse_Validate(t *testing.T) {
 		schema := &openapi3.Schema{
 			If: &openapi3.SchemaRef{Ref: "#/components/schemas/Missing"},
 		}
-		err := schema.Validate(context.Background())
+		err := schema.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
 		require.Error(t, err)
 		require.ErrorContains(t, err, "unresolved ref")
 	})
@@ -185,7 +185,7 @@ func TestSchemaIfThenElse_Validate(t *testing.T) {
 		schema := &openapi3.Schema{
 			Then: &openapi3.SchemaRef{Ref: "#/components/schemas/Missing"},
 		}
-		err := schema.Validate(context.Background())
+		err := schema.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
 		require.Error(t, err)
 		require.ErrorContains(t, err, "unresolved ref")
 	})
@@ -194,7 +194,7 @@ func TestSchemaIfThenElse_Validate(t *testing.T) {
 		schema := &openapi3.Schema{
 			Else: &openapi3.SchemaRef{Ref: "#/components/schemas/Missing"},
 		}
-		err := schema.Validate(context.Background())
+		err := schema.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
 		require.Error(t, err)
 		require.ErrorContains(t, err, "unresolved ref")
 	})
@@ -205,7 +205,7 @@ func TestSchemaIfThenElse_Validate(t *testing.T) {
 			Then: &openapi3.SchemaRef{Value: &openapi3.Schema{MinLength: 1}},
 			Else: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"number"}}},
 		}
-		err := schema.Validate(context.Background())
+		err := schema.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
 		require.NoError(t, err)
 	})
 }

--- a/openapi3/schema_validate_31_test.go
+++ b/openapi3/schema_validate_31_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestSchemaValidate31SubSchemas(t *testing.T) {
-	ctx := context.Background()
+	ctx := openapi3.WithValidationOptions(context.Background(), openapi3.IsOpenAPI31OrLater())
 
 	// Helper: a schema with an invalid nested schema (pattern with bad regex)
 	invalidSchema := &openapi3.Schema{


### PR DESCRIPTION
Follow-up to your review comments on [oasdiff/kin-openapi#15](https://github.com/oasdiff/kin-openapi/pull/15):

> 1. Regarding v3.1 sibling fields: this was missing tests which I added
> 2. Also please complete the implementation of applySiblingSchemaFields. I can't merge this with this regression for 3.0.
> 3. go over the Schema's Validate func and gate the usage of v3.1 fields
> 4. the later will end up being a noop once I replace v3.0's custom schema validation with the new one
> 5. try to not squash the commits

Six commits, one logical change each:

1. **`complete applySiblingSchemaFields with all Schema fields`** — addresses your FIXME; the helper now covers every field in the `Schema` struct rather than the original 8.
2. **`extract validateExtras helper for all Ref types`** — template + regen only; no behaviour change. Pulls the extras check out of `(*Ref).Validate` into a standalone method so it can be invoked from nested-ref validation sites.
3. **`validate $ref siblings at nested SchemaRefs, fixing 3.0 regression`** — makes `TestSchemaRefSiblingKeyword/{3.0 false false}` pass. Root cause: `validateExtras` was only called from `SchemaRef.Validate`, which nested schema validation bypassed by recursing directly into `ref.Value.Validate`. Now invoked at every nested site (items, properties, additionalProperties, prefixItems, contains, patternProperties, dependentSchemas, \$defs, propertyNames, unevaluated*, contentSchema, if/then/else). Drops the `t.Skip` too.
4. **`update TestIssue601`** — lxkns.yaml (OAS 3.0.2) uses `description` as a sibling to \$ref throughout. Nested-ref validation now catches that and masks the example-type mismatch the test targets. Pass `AllowExtraSiblingFields("description")` so the test reaches its real assertion, matching the existing pattern in issue513.
5. **`gate OAS 3.1 schema fields from OAS 3.0 validation`** — addresses your point 3. Rejects `prefixItems`, `contains`, `if/then/else`, `\$defs`, `\$schema`, `patternProperties`, `unevaluated*`, `contentSchema`, etc. in OAS 3.0 via `errFieldFor31Plus`. Honours `AllowExtraSiblingFields` as an opt-in escape hatch (mirrors the existing mechanism used by `TestExtraSiblingsInRemoteRef`). Becomes a no-op once OAS 3.0 gets its own validator (your point 4).
6. **`update tests for OAS 3.1 field gate`** — three tests needed small adjustments: `TestSchemaIfThenElse_Validate` and `TestSchemaValidate31SubSchemas` exercise 3.1 features via `schema.Validate` directly (no doc), so they now pass `IsOpenAPI31OrLater()` explicitly. `TestIssue495WithDraft04{,Bis}` load OAS 3.0 docs \$ref-ing external JSON Schema draft-04 meta-schemas; they pass `AllowExtraSiblingFields("\$id", "\$schema")` so the inner-ref assertion they target still surfaces.

Every commit builds standalone; HEAD passes `go generate`, `go fmt`, `go vet`, `go mod tidy`, `docs.sh`, `go test ./...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)